### PR TITLE
Updated link generation to work like Obsidian.

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -11,6 +11,7 @@ export function generateLink(header: string, tabsOverride?: string): string {
     let tabs = "";
     let h = "";
     let headerTitle = "";
+    let headerLink = "";
     for (let i = 0; i < header.length; ++i) {
         const char = header[i];
         if (char === "#") {
@@ -18,6 +19,7 @@ export function generateLink(header: string, tabsOverride?: string): string {
             h += "#";
         } else {
             headerTitle = header.substring(i);
+            headerLink = header.substring(i).replace(/[#|\\^: ]+/g," ").trim()
             break;
         }
     }
@@ -26,7 +28,7 @@ export function generateLink(header: string, tabsOverride?: string): string {
     tabs = tabs.slice(0, -1);
     if (tabsOverride != null) tabs = tabsOverride;
 
-    return `${tabs}- [${headerTitle}](${h}${headerTitle.replaceAll(
+    return `${tabs}- [${headerTitle}](${h}${headerLink.replaceAll(
         " ",
         "%20",
     )})`;


### PR DESCRIPTION
I did this with manual testing using the disallowed characters. Since the links are generated broken anyway, if this fix doesn't work for some specific set of characters the users is in the same place as if it wasn't here.

I use a website to markdown plugin that generates hideous headers and I have had to manually fix them so PotatoIndexer can correctly create content index links. Adding this makes ugly headers link without hassle. Colon's are the biggest thing that people use all the time in headers but aren't valid link characters.

example: `# \## Appendix: A personal| ^length-li\|||m\iting example`
becomes: `[\## Appendix: A personal| ^length-li\|||m\iting example](##Appendix%20A%20personal%20length-li%20m%20iting%20example)`

Now the only difference between Obsidian's default link generation and PotatoIndexer is that the indexer uses the depth of the header in the link while obsidian doesn't. The links work either way and that's the historical functionality so I don't think that it matters.

As always, let me know if you want me to make any changes.
