### PR TITLE
Data loss bug if the extension runs into a list of markdown url's.

### DIFF
--- a/src/indexSvc.ts
+++ b/src/indexSvc.ts
@@ -14,6 +14,7 @@ export function generateIndex(
     const indexPos: number[] = [];
     let contents = "";
     let indexFound = false;
+    let headerAfterIndex = false;
     let propertiesFound = false;
     let endPropertiesPos = 0;
     let countTripDash = 0;
@@ -33,9 +34,10 @@ export function generateIndex(
             indexPos[0] = i;
             indexPos[1] = i;
             indexFound = true;
-        } else if (indexFound && line.includes("- [")) {
+        } else if (indexFound && line.includes("- [") && !headerAfterIndex) {
             indexPos[1] = i;
         } else if (line.length > 0 && line[0] === "#") {
+            if (indexFound) headerAfterIndex = true;
             if (indexPos.length === 0) {
                 // NOTE: We haven't found the index so far, so assume it doesn't exist
                 if (settings.insertAfterFirstHeader) {

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -140,6 +140,8 @@ describe("insert after header false", function () {
 # Title one
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text`;
 
@@ -166,6 +168,8 @@ And this is our final text after two Horizontal Rules.`;
 # Title one
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text`;
 
@@ -185,6 +189,8 @@ property1: prop1
 # Title one
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text`;
         assert.equal(genNote, expected);
@@ -206,6 +212,8 @@ property1: prop1
 # Title one
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text
 ---
@@ -228,6 +236,8 @@ And this is our final text after two Horizontal Rules.`;
 # Title one
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text
 ---
@@ -249,6 +259,8 @@ And this is our final text after two Horizontal Rules.`;
 # Title one
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text
 
@@ -265,6 +277,8 @@ In the second one I am text
 # Title one
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text
 
@@ -286,6 +300,8 @@ describe("custom header to look for", function () {
 # Title one
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text`;
 
@@ -300,6 +316,8 @@ In the second one I am text`;
 	- [Title two](##Title%20two)
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text`;
 
@@ -316,6 +334,8 @@ In the second one I am text`;
 	- [Title two](##Title%20two)
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text
 
@@ -333,6 +353,8 @@ In the second one I am text
 - [Post title](#Post%20title)
 
 ## Title two
+- [[Link1]]
+- [[Link2]]
 
 In the second one I am text
 


### PR DESCRIPTION
The logic to update the TOC range is faulty if the document contains a list of markdown URL's elsewhere in the document.
The changes here prevent this from happening by tracking the end of the TOC so we don't update the TOC range after it was already identified. I added test cases to watch for any future regressions as well.